### PR TITLE
Init

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @GailMelanie @hofermo @JonathanXITASO @pawel-baran-se @XAlinaGS @NilsXitaso @milofranke @sirchnik-xitaso

--- a/compose.yml
+++ b/compose.yml
@@ -12,8 +12,10 @@ services:
     ports:
       - '5065:5065'
     environment:
-    # API key authorization
+      # API key authorization
       CustomerEndpointsSecurity__ApiKey: ${MNESTIX_BACKEND_API_KEY:-verySecureApiKey}
+      # AzureAd
+      AzureAd__EnableAzureAdAuth: "false"
       # Connection to Repository Service:
       ReverseProxy__Clusters__mnestixApiCluster__Destinations__destination1__Address: 'http://mnestix-api:5064/'
       ReverseProxy__Clusters__aasRepoCluster__Destinations__destination1__Address: 'http://aas-environment:8081/'
@@ -25,7 +27,7 @@ services:
       # Token:
       ReverseProxy__Routes__InfluxRoute__Transforms__1__Set: 'Token '
       # OpenID Configuration
-      OpenId__EnableOpenIdAuth: "true"
+      OpenId__EnableOpenIdAuth: "false"
       OpenId__Issuer: "http://keycloak:8080/realms/Mnestix"
       OpenId__ClientID: "mnestixApi-demo"
       OpenId__RequireHttpsMetadata: "false"
@@ -101,6 +103,8 @@ services:
     profiles: ['', 'basyx', 'tests']
     depends_on:
       - mongodb
+    ports:
+      - '8081:8081'
     environment:
       # MongoDb configuration for Basyx Repository
       BASYX__BACKEND: MongoDB

--- a/compose.yml
+++ b/compose.yml
@@ -103,8 +103,6 @@ services:
     profiles: ['', 'basyx', 'tests']
     depends_on:
       - mongodb
-    ports:
-      - '8081:8081'
     environment:
       # MongoDb configuration for Basyx Repository
       BASYX__BACKEND: MongoDB

--- a/mnestix-proxy/Authentication/AuthenticationServicesRegistration.cs
+++ b/mnestix-proxy/Authentication/AuthenticationServicesRegistration.cs
@@ -57,8 +57,9 @@ public static class AuthenticationServicesRegistration
         else {
             services.AddAuthentication(options =>
             {
-                options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
-            }).AddJwtBearer();
+                options.DefaultAuthenticateScheme = null;
+                options.DefaultChallengeScheme = null;
+            });
         }
     }
 }


### PR DESCRIPTION
This pull request introduces changes to authentication configurations, focusing on disabling certain authentication mechanisms and updating related service registrations. These changes primarily affect the `compose.yml` file and the `AuthenticationServicesRegistration.cs` file.

### Authentication Configuration Updates:

* **Azure AD Authentication Disabled**: Added a new environment variable `AzureAd__EnableAzureAdAuth` with a default value of `"false"`, disabling Azure Active Directory authentication. (`compose.yml`, [compose.ymlR17-R18](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588R17-R18))
* **OpenID Authentication Disabled**: Modified the `OpenId__EnableOpenIdAuth` environment variable to `"false"`, effectively disabling OpenID authentication. (`compose.yml`, [compose.ymlL28-R30](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588L28-R30))

### Authentication Configuration Updates:
* [`compose.yml`](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588R17-R18): Added `AzureAd__EnableAzureAdAuth` environment variable with a default value of `"false"` to configure Azure AD authentication.
* [`compose.yml`](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588L28-R30): Changed `OpenId__EnableOpenIdAuth` environment variable default value from `"true"` to `"false"` to disable OpenID authentication by default.
* [`mnestix-proxy/Authentication/AuthenticationServicesRegistration.cs`](diffhunk://#diff-362eeee3c72937d05bdf550e5f737d18039e9155f30be6663084be3446945eb2L60-R62): Updated the default authentication scheme by setting `DefaultAuthenticateScheme` and `DefaultChallengeScheme` to `null` in the `AddAuthenticationServices` method.

### Ownership Updates:
* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7R1): Added multiple users as code owners for the repository.