### PR TITLE
refactor: change the header for API-KEY

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -103,6 +103,8 @@ services:
     profiles: ['', 'basyx', 'tests']
     depends_on:
       - mongodb
+    ports:
+      - '8081:8081'
     environment:
       # MongoDb configuration for Basyx Repository
       BASYX__BACKEND: MongoDB

--- a/compose.yml
+++ b/compose.yml
@@ -43,6 +43,7 @@ services:
     ports:
       - '5064:5064'
     environment:
+      ServerUrls ServerUrls: 'http://mnestix-proxy:5065/repo/'
       # API key authorization
       CustomerEndpointsSecurity__ApiKey: ${MNESTIX_BACKEND_API_KEY:-verySecureApiKey}
       # Connection to Repository Service:

--- a/mnestix-proxy.Tests/TestMockService/DownstreamService.cs
+++ b/mnestix-proxy.Tests/TestMockService/DownstreamService.cs
@@ -28,7 +28,7 @@ namespace mnestix_proxy.Tests.TestMockService
                                   {
                                       var path = context.Request.Path.Value?.ToLowerInvariant();
 
-                                      if (path != null && path.StartsWith("/test-endpoint"))
+                                      if (path != null && path.StartsWith("/api/test-endpoint"))
                                       {
                                           context.Response.StatusCode = 200;
                                           await context.Response.WriteAsync("Mnestix Api called!");

--- a/mnestix-proxy/Authentication/ApiKeyAuthentication/ApiKeyRequirementHandler.cs
+++ b/mnestix-proxy/Authentication/ApiKeyAuthentication/ApiKeyRequirementHandler.cs
@@ -53,6 +53,6 @@ public class ApiKeyRequirementHandler(
             _httpContextAccessor.HttpContext?.Request.Method, 
             _httpContextAccessor.HttpContext?.Request.Path);
         context.Fail(new AuthorizationFailureReason(this,
-            "For all methods except 'GET' you need a valid ApiKey in your header."));
+            "For all methods except 'GET' you need a valid X-API-KEY in your header."));
     }
 }

--- a/mnestix-proxy/Authentication/ApiKeyAuthentication/AuthorizationMiddlewareResultHandler.cs
+++ b/mnestix-proxy/Authentication/ApiKeyAuthentication/AuthorizationMiddlewareResultHandler.cs
@@ -39,7 +39,6 @@ namespace mnestix_proxy.Authentication.ApiKeyAuthentication
                 return;
             }
 
-            // Proceed normally
             await _defaultHandler.HandleAsync(next, context, policy, authorizeResult);
         }
     }

--- a/mnestix-proxy/Authentication/ApiKeyAuthentication/AuthorizationMiddlewareResultHandler.cs
+++ b/mnestix-proxy/Authentication/ApiKeyAuthentication/AuthorizationMiddlewareResultHandler.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.AspNetCore.Authorization.Policy;
+using Microsoft.AspNetCore.Authorization;
+
+namespace mnestix_proxy.Authentication.ApiKeyAuthentication
+{
+    public class CustomAuthorizationMiddlewareResultHandler : IAuthorizationMiddlewareResultHandler
+    {
+        private readonly AuthorizationMiddlewareResultHandler _defaultHandler = new();
+
+        public async Task HandleAsync(RequestDelegate next, HttpContext context,
+            AuthorizationPolicy policy, PolicyAuthorizationResult authorizeResult)
+        {
+            if (authorizeResult.Forbidden)
+            {
+                context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                context.Response.ContentType = "application/json";
+
+                var message = "Forbidden";
+                if (authorizeResult.AuthorizationFailure?.FailureReasons?.Any() == true)
+                {
+                    message = authorizeResult.AuthorizationFailure.FailureReasons
+                        .Select(r => r.Message)
+                        .FirstOrDefault() ?? message;
+                }
+
+                await context.Response.WriteAsJsonAsync(new { error = message });
+                return;
+            }
+
+            if (authorizeResult.Challenged)
+            {
+                context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                context.Response.ContentType = "application/json";
+
+                await context.Response.WriteAsJsonAsync(new
+                {
+                    error = "Unauthorized: You must provide valid authentication credentials."
+                });
+                return;
+            }
+
+            // Proceed normally
+            await _defaultHandler.HandleAsync(next, context, policy, authorizeResult);
+        }
+    }
+
+}

--- a/mnestix-proxy/Authentication/ApplicationBuilderAuthExtensions.cs
+++ b/mnestix-proxy/Authentication/ApplicationBuilderAuthExtensions.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace mnestix_proxy.Authentication
+{
+    public static class ApplicationBuilderAuthExtensions
+    {
+        public static IApplicationBuilder UseMnestixConfiguredAuth(this IApplicationBuilder app, IConfiguration configuration)
+        {
+            var openIdEnabled = configuration.GetSection("OpenId").GetValue("EnableOpenIdAuth", false);
+            var azureAdEnabled = configuration.GetSection("AzureAd").GetValue("EnableAzureAdAuth", false);
+
+            if (openIdEnabled || azureAdEnabled) {
+                app.UseAuthentication();
+                app.UseAuthorization();
+            }
+
+            return app;
+        }
+    }
+}

--- a/mnestix-proxy/Authentication/AuthenticationServicesRegistration.cs
+++ b/mnestix-proxy/Authentication/AuthenticationServicesRegistration.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.Identity.Web;
 using Microsoft.IdentityModel.Tokens;
+using mnestix_proxy.Authentication.ApiKeyAuthentication;
 
 namespace mnestix_proxy.Authentication;
 
@@ -55,11 +57,7 @@ public static class AuthenticationServicesRegistration
             services.AddMicrosoftIdentityWebApiAuthentication(configuration);
         }
         else {
-            services.AddAuthentication(options =>
-            {
-                options.DefaultAuthenticateScheme = null;
-                options.DefaultChallengeScheme = null;
-            });
+            services.AddSingleton<IAuthorizationMiddlewareResultHandler, CustomAuthorizationMiddlewareResultHandler>();
         }
     }
 }

--- a/mnestix-proxy/Program.cs
+++ b/mnestix-proxy/Program.cs
@@ -49,8 +49,9 @@ namespace mnestix_proxy
             // pipeline settings
             var app = builder.Build();
 
-            app.UseAuthentication();
-            app.UseAuthorization();
+            app.UseMnestixConfiguredAuth(builder.Configuration);
+
+            app.UseCors("allowAnything");
 
             app.MapReverseProxy(proxyPipeline =>
             {

--- a/mnestix-proxy/appsettings.json
+++ b/mnestix-proxy/appsettings.json
@@ -22,7 +22,7 @@
   },
   // if both OpenId and AzureAd are enabled OpenId will be used
   "OpenId": {
-    "EnableOpenIdAuth": "true",
+    "EnableOpenIdAuth": "false",
     "Issuer": "http://localhost:8080/realms/Menstix",
     "ClientID": "mnestixApi-demo",
     "RequireHttpsMetadata": "false"
@@ -39,7 +39,7 @@
         "AuthorizationPolicy": "customApiKeyToModifyValuesPolicy",
         "Match": {
           "Path": "api/{**catch-all}"
-          }
+        }
       },
       "EnvironmentRoute": {
         "ClusterId": "aasRepoCluster",

--- a/mnestix-proxy/appsettings.json
+++ b/mnestix-proxy/appsettings.json
@@ -9,7 +9,7 @@
     "ApiKey": "9FB8BCDFAEE81367A1668E16BDC37"
   },
   "AzureAd": {
-    "EnableAzureAdAuth": "true",
+    "EnableAzureAdAuth": "false",
     "Instance": "https://login.microsoftonline.com/",
     "ClientId": "ffade4c2-76c8-44fd-9258-743d9cfc2289",
     "CallbackPath": "",
@@ -23,7 +23,7 @@
   // if both OpenId and AzureAd are enabled OpenId will be used
   "OpenId": {
     "EnableOpenIdAuth": "true",
-    "Issuer": "http://localhost:8080/realms/BaSyx",
+    "Issuer": "http://localhost:8080/realms/Menstix",
     "ClientID": "mnestixApi-demo",
     "RequireHttpsMetadata": "false"
   },
@@ -39,14 +39,6 @@
         "AuthorizationPolicy": "customApiKeyToModifyValuesPolicy",
         "Match": {
           "Path": "api/{**catch-all}"
-        },
-        "Transforms": [
-          {
-            "PathPattern": "/{**catch-all}"
-          },
-          {
-            "ResponseHeader": "Access-Control-Allow-Origin",
-            "Set": "*"
           }
         ]
       },

--- a/mnestix-proxy/appsettings.json
+++ b/mnestix-proxy/appsettings.json
@@ -40,7 +40,6 @@
         "Match": {
           "Path": "api/{**catch-all}"
           }
-        ]
       },
       "EnvironmentRoute": {
         "ClusterId": "aasRepoCluster",


### PR DESCRIPTION
This pull request introduces several changes to enhance authentication, improve error handling, and update configurations in the `mnestix-proxy` project. The key updates include replacing default authentication handling with custom middleware, modifying endpoint paths and error messages, and adjusting configuration settings for OpenID and Azure AD authentication.

### Authentication Enhancements:
* Added `CustomAuthorizationMiddlewareResultHandler` to handle authorization failures and challenges with custom JSON error responses. (`mnestix-proxy/Authentication/ApiKeyAuthentication/AuthorizationMiddlewareResultHandler.cs`)
* Introduced `ApplicationBuilderAuthExtensions` to conditionally enable authentication and authorization middleware based on configuration settings. (`mnestix-proxy/Authentication/ApplicationBuilderAuthExtensions.cs`)
* Updated `AuthenticationServicesRegistration` to register the custom authorization middleware handler instead of default authentication schemes. (`mnestix-proxy/Authentication/AuthenticationServicesRegistration.cs`)

### Configuration Updates:
* Disabled OpenID and Azure AD authentication by default in `appsettings.json` and updated the OpenID issuer URL. (`mnestix-proxy/appsettings.json`) [[1]](diffhunk://#diff-b877a09102083cb6213179e91151dbdc6d7333b1da0fc05d73506a835626fe43L12-R12) [[2]](diffhunk://#diff-b877a09102083cb6213179e91151dbdc6d7333b1da0fc05d73506a835626fe43L25-R26)
* Removed unused reverse proxy transforms from the `appsettings.json` configuration. (`mnestix-proxy/appsettings.json`)

### Code Improvements:
* Replaced repetitive `UseAuthentication` and `UseAuthorization` calls with the new `UseMnestixConfiguredAuth` extension method. (`mnestix-proxy/Program.cs`)
* Updated error message in `ApiKeyRequirementHandler` to specify the required header name (`X-API-KEY`). (`mnestix-proxy/Authentication/ApiKeyAuthentication/ApiKeyRequirementHandler.cs`)

### Endpoint Adjustments:
* Changed the test endpoint path in `DownstreamService` to include `/api` prefix for consistency. (`mnestix-proxy.Tests/TestMockService/DownstreamService.cs`)

### Miscellaneous:
* Exposed port `8081` in the `compose.yml` file for containerized services. (`compose.yml`)