### PR TITLE
Release 1.0.1 - Fixed CORS-Handling

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,7 +11,7 @@ env:
   # github.repository as <account>/<repo>
   IMAGE_NAME: mnestix-proxy
   # Update the version manually
-  IMAGE_TAG_VERSION: 1.0.0
+  IMAGE_TAG_VERSION: 1.0.1
 
 jobs:
   run-tests:

--- a/compose.yml
+++ b/compose.yml
@@ -6,7 +6,7 @@
 services:
   mnestix-proxy:
     container_name: mnestix-proxy
-    image: mnestix/mnestix-proxy:1.0.0
+    image: mnestix/mnestix-proxy:1.0.1
     ports:
       - '5065:5065'
     environment:

--- a/mnestix-proxy.Tests/AuthenticationTests/ApiKeyRequirementHandlerTests.cs
+++ b/mnestix-proxy.Tests/AuthenticationTests/ApiKeyRequirementHandlerTests.cs
@@ -27,7 +27,7 @@ namespace mnestix_proxy.Tests.AuthenticationTests
         [TestCase("/repo/shells/mockBase64EncodedAasId", "GET")]
         [TestCase("/repo/submodels", "GET")]
         [TestCase("/repo/submodels/mockBase64EncodedSubmodelId", "GET")]
-        public async Task Should_Succeed_For_GET_and_HEAD_Requests_Without_ApiKey(string path, string method)
+        public async Task Should_Succeed_For_GET_OPTIONS_HEAD_Requests_Without_ApiKey(string path, string method)
         {
             // Act
             var request = new HttpRequestMessage(new HttpMethod(method), path);

--- a/mnestix-proxy.Tests/AuthenticationTests/ApiKeyRequirementHandlerTests.cs
+++ b/mnestix-proxy.Tests/AuthenticationTests/ApiKeyRequirementHandlerTests.cs
@@ -22,6 +22,7 @@ namespace mnestix_proxy.Tests.AuthenticationTests
         }
 
         [TestCase("/repo/shells", "GET")]
+        [TestCase("/repo/shells", "OPTIONS")]
         [TestCase("/repo/shells", "HEAD")]
         [TestCase("/repo/shells/mockBase64EncodedAasId", "GET")]
         [TestCase("/repo/submodels", "GET")]

--- a/mnestix-proxy.Tests/mnestix-proxy.Tests.csproj
+++ b/mnestix-proxy.Tests/mnestix-proxy.Tests.csproj
@@ -11,12 +11,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="coverlet.collector" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.15" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="NUnit" Version="4.5.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.11.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
     <PackageReference Include="Yarp.ReverseProxy" Version="2.3.0" />
   </ItemGroup>
 

--- a/mnestix-proxy/Authentication/ApiKeyAuthentication/ApiKeyRequirementHandler.cs
+++ b/mnestix-proxy/Authentication/ApiKeyAuthentication/ApiKeyRequirementHandler.cs
@@ -33,7 +33,7 @@ public class ApiKeyRequirementHandler(
     private void SucceedRequirementIfApiKeyPresentAndValid(AuthorizationHandlerContext context,
         IAuthorizationRequirement requirement)
     {
-        if (_httpContextAccessor.HttpContext?.Request.Method is "GET" or "HEAD")
+        if (_httpContextAccessor.HttpContext?.Request.Method is "GET" or "HEAD" or "OPTIONS")
         {
             context.Succeed(requirement);
             return;

--- a/mnestix-proxy/Program.cs
+++ b/mnestix-proxy/Program.cs
@@ -49,9 +49,10 @@ namespace mnestix_proxy
             // pipeline settings
             var app = builder.Build();
 
-            app.UseMnestixConfiguredAuth(builder.Configuration);
-
+            // IMPORTANT: apply CORS BEFORE authentication so preflight OPTIONS are handled
             app.UseCors("allowAnything");
+
+            app.UseMnestixConfiguredAuth(builder.Configuration);
 
             app.MapReverseProxy(proxyPipeline =>
             {

--- a/mnestix-proxy/mnestix-proxy.csproj
+++ b/mnestix-proxy/mnestix-proxy.csproj
@@ -11,11 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Web" Version="3.8.4" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
-    <PackageReference Include="MQTTnet" Version="5.0.1.1416" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="RestSharp" Version="112.1.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="4.3.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
+    <PackageReference Include="MQTTnet" Version="5.1.0.1559" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="RestSharp" Version="113.1.0" />
     <PackageReference Include="Yarp.ReverseProxy" Version="2.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This pull request updates the proxy service to improve CORS preflight request handling and increment the Docker image version. The main change is to allow unauthenticated `OPTIONS` requests (used for CORS preflight) by updating both the authentication logic and the test suite. Additionally, the Docker image version is bumped from `1.0.0` to `1.0.1` in relevant configuration files.

**CORS and Authentication Improvements:**

* Updated the authentication handler in `ApiKeyRequirementHandler.cs` to allow unauthenticated `OPTIONS` requests, in addition to `GET` and `HEAD` requests, by checking for the `OPTIONS` method.
* Changed the middleware order in `Program.cs` to apply CORS before authentication, ensuring preflight `OPTIONS` requests are handled properly.

**Testing Updates:**

* Expanded the test suite in `ApiKeyRequirementHandlerTests.cs` to include `OPTIONS` requests, ensuring that unauthenticated `OPTIONS` requests succeed as intended.

**Version Bump:**

* Updated the Docker image version from `1.0.0` to `1.0.1` in both `.github/workflows/docker-build.yml` and `compose.yml` to reflect the new release. [[1]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L14-R14) [[2]](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588L9-R9)