### PR TITLE
Updated nuget_packages

### DIFF
--- a/mnestix-proxy.Tests/mnestix-proxy.Tests.csproj
+++ b/mnestix-proxy.Tests/mnestix-proxy.Tests.csproj
@@ -11,12 +11,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="coverlet.collector" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.15" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="NUnit" Version="4.5.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.11.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
     <PackageReference Include="Yarp.ReverseProxy" Version="2.3.0" />
   </ItemGroup>
 

--- a/mnestix-proxy/mnestix-proxy.csproj
+++ b/mnestix-proxy/mnestix-proxy.csproj
@@ -11,11 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Web" Version="3.8.4" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
-    <PackageReference Include="MQTTnet" Version="5.0.1.1416" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="RestSharp" Version="112.1.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="4.3.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
+    <PackageReference Include="MQTTnet" Version="5.1.0.1559" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="RestSharp" Version="113.1.0" />
     <PackageReference Include="Yarp.ReverseProxy" Version="2.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This pull request updates several NuGet package dependencies in both the main project and its test project to newer versions. These updates help ensure compatibility, access to new features, and security improvements.

Dependency updates:

**Test project (`mnestix-proxy.Tests.csproj`):**
* Upgraded `coverlet.collector` to 8.0.0, `Microsoft.NET.Test.Sdk` to 18.0.1, `NUnit` to 4.5.0, `NUnit.Analyzers` to 4.11.2, and `NUnit3TestAdapter` to 6.1.0.

**Main project (`mnestix-proxy.csproj`):**
* Upgraded `Microsoft.Identity.Web` to 4.3.0, `Microsoft.VisualStudio.Azure.Containers.Tools.Targets` to 1.23.0, `MQTTnet` to 5.1.0.1559, `Newtonsoft.Json` to 13.0.4, and `RestSharp` to 113.1.0.