### PR TITLE
feat: Add Registry and Repository Routes Configuration

### DIFF
--- a/mnestix-proxy/appsettings.json
+++ b/mnestix-proxy/appsettings.json
@@ -73,6 +73,54 @@
           }
         ]
       },
+      "ConceptDescriptionRepositoryRoute": {
+        "ClusterId": "conceptDescriptionRepoCluster",
+        "AuthorizationPolicy": "customApiKeyToModifyValuesPolicy",
+        "Match": {
+          "Path": "repo/concept-descriptions/{**remainder}"
+        },
+        "Transforms": [
+          {
+            "PathPattern": "/concept-descriptions/{**remainder}"
+          },
+          {
+            "ResponseHeader": "Access-Control-Allow-Origin",
+            "Set": "*"
+          }
+        ]
+      },
+      "AasRegistryRoute": {
+        "ClusterId": "aasRegistryCluster",
+        "AuthorizationPolicy": "customApiKeyToModifyValuesPolicy",
+        "Match": {
+          "Path": "registry/shell-descriptors/{**catch-all}"
+        },
+        "Transforms": [
+          {
+            "PathPattern": "/shell-descriptors/{**catch-all}"
+          },
+          {
+            "ResponseHeader": "Access-Control-Allow-Origin",
+            "Set": "*"
+          }
+        ]
+      },
+      "SubmodelRegistryRoute": {
+        "ClusterId": "submodelRegistryCluster",
+        "AuthorizationPolicy": "customApiKeyToModifyValuesPolicy",
+        "Match": {
+          "Path": "registry/submodel-descriptors/{**remainder}"
+        },
+        "Transforms": [
+          {
+            "PathPattern": "/submodel-descriptors/{**remainder}"
+          },
+          {
+            "ResponseHeader": "Access-Control-Allow-Origin",
+            "Set": "*"
+          }
+        ]
+      },
       "DiscoveryRoute": {
         "ClusterId": "discoveryCluster",
         "AuthorizationPolicy": "customApiKeyToModifyValuesPolicy",
@@ -122,6 +170,27 @@
         }
       },
       "submodelRepoCluster": {
+        "Destinations": {
+          "destination1": {
+            "Address": "http://localhost:8081/"
+          }
+        }
+      },
+      "conceptDescriptionRepoCluster": {
+        "Destinations": {
+          "destination1": {
+            "Address": "http://localhost:8081/"
+          }
+        }
+      },
+      "aasRegistryCluster": {
+        "Destinations": {
+          "destination1": {
+            "Address": "http://localhost:8081/"
+          }
+        }
+      },
+       "submodelRegistryCluster": {
         "Destinations": {
           "destination1": {
             "Address": "http://localhost:8081/"

--- a/wiki/Proxy-Configuration-Settings.md
+++ b/wiki/Proxy-Configuration-Settings.md
@@ -40,6 +40,24 @@ Defines how incoming requests are matched and routed to clusters:
   - Authorization: `customApiKeyToModifyValuesPolicy`
   - Transforms: Path pattern and CORS header
 
+- **ConceptDescriptionRepositoryRoute** - This route is configuration to the concept description repository.
+  - Path: `repo/concept-descriptions/{**remainder}`
+  - Cluster: `conceptDescriptionRepoCluster`
+  - Authorization: `customApiKeyToModifyValuesPolicy`
+  - Transforms: Path pattern and CORS header
+
+- **AasRegistryRoute** - This route forwards requests to the AAS Registry.
+  - Path: `registry/shell-descriptors/{**catch-all}`
+  - Cluster: `aasRegistryCluster`
+  - Authorization: `customApiKeyToModifyValuesPolicy`
+  - Transforms: Path pattern and CORS header
+
+- **SubmodelRegistryRoute** - This route forwards requests to the Submodel Registry.
+  - Path: `registry/submodel-descriptors/{**remainder}`
+  - Cluster: `submodelRegistryCluster`
+  - Authorization: `customApiKeyToModifyValuesPolicy`
+  - Transforms: Path pattern and CORS header
+
 - **DiscoveryRoute** - This route is configuration to discovery service (required for 'AasDiscoveryMiddleware').
   - Path: `discovery/{**catch-all}`
   - Cluster: `discoveryCluster`
@@ -59,6 +77,9 @@ Defines backend destinations for each route:
 - **mnestixApiCluster**: `http://localhost:5064/`
 - **aasRepoCluster**: `http://localhost:8081/`
 - **submodelRepoCluster**: `http://localhost:8081/`
+- **conceptDescriptionRepoCluster**: `http://localhost:8081/`
+- **aasRegistryCluster**: `http://localhost:8081/`
+- **submodelRegistryCluster**: `http://localhost:8081/`
 - **discoveryCluster**: `http://localhost:8082/`
 - **influxCluster**: `http://<your-domain>:<port>`
 


### PR DESCRIPTION
## MR Overview: Add Registry and Repository Routes Configuration

### Summary
This MR introduces three new routing configurations for the mnestix-proxy, enabling support for Concept Description Repository, AAS Registry, and Submodel Registry services.

### Changes

#### Configuration Updates (`mnestix-proxy/appsettings.json`)
- **3 New Routes Added:**
  - `ConceptDescriptionRepositoryRoute` - Routes requests to concept description repository at `repo/concept-descriptions/{**remainder}`
  - `AasRegistryRoute` - Routes requests to AAS Registry at `registry/shell-descriptors/{**catch-all}`
  - `SubmodelRegistryRoute` - Routes requests to Submodel Registry at `registry/submodel-descriptors/{**remainder}`

- **3 New Clusters Added:**
  - `conceptDescriptionRepoCluster` - Points to `http://localhost:8081/`
  - `aasRegistryCluster` - Points to `http://localhost:8081/`
  - `submodelRegistryCluster` - Points to `http://localhost:8081/`

**Common Configuration:**
- All new routes use the `customApiKeyToModifyValuesPolicy` authorization policy
- Each includes path transformation and CORS header response configuration

#### Documentation Updates (`wiki/Proxy-Configuration-Settings.md`)
- Documented the three new routes with their paths, clusters, and authorization policies
- Added cluster definitions to the backend destinations section

### Type
- Configuration & Documentation

### Files Modified
- `mnestix-proxy/appsettings.json` (81 lines added)
- `wiki/Proxy-Configuration-Settings.md` (24 lines added)