### PR TITLE
Added AAS Registry Middleware

### DIFF
--- a/mnestix-proxy.Tests/IntegrationTestBase.cs
+++ b/mnestix-proxy.Tests/IntegrationTestBase.cs
@@ -19,10 +19,13 @@ namespace mnestix_proxy.Tests
                 {
                     { "CustomerEndpointsSecurity:ApiKey", "verySecureApiKeyMock" },
                     { "Features:AllowRetrievingAllShellsAndSubmodels", "true" },
+                    { "Features:AasDiscoveryMiddleware", "false" },
+                    { "Features:AasRegistryMiddleware", "false" },
                     { "ReverseProxy:Clusters:mnestixApiCluster:Destinations:destination1:Address", _downstreamUrl },
                     { "ReverseProxy:Clusters:aasRepoCluster:Destinations:destination1:Address", _downstreamUrl },
                     { "ReverseProxy:Clusters:submodelRepoCluster:Destinations:destination1:Address", _downstreamUrl },
                     { "ReverseProxy:Clusters:discoveryCluster:Destinations:destination1:Address", _downstreamUrl },
+                    { "ReverseProxy:Clusters:aasRegistryCluster:Destinations:destination1:Address", _downstreamUrl },
                 };
 
                 if (_customSettings != null)

--- a/mnestix-proxy.Tests/MiddlewareTests/AasRegistryServiceMiddlewareTests.cs
+++ b/mnestix-proxy.Tests/MiddlewareTests/AasRegistryServiceMiddlewareTests.cs
@@ -1,0 +1,149 @@
+using mnestix_proxy.Services.Shared;
+using mnestix_proxy.Tests.TestMockService;
+using System.Text;
+
+namespace mnestix_proxy.Tests.MiddlewareTests
+{
+    [TestFixture]
+    public class AasRegistryServiceMiddlewareTests : IDisposable
+    {
+        private DownstreamService _mockDownstream = null!;
+        private RegistryMockService _mockRegistry = null!;
+        private HttpClient _httpClientEnabled = null!;
+        private HttpClient _httpClientDisabled = null!;
+
+        private const string AasId = "urn:example:test-aas";
+        private const string AssetId = "urn:example:test-asset";
+
+        private static readonly string ValidAasBody = """
+            {
+                "modelType": "AssetAdministrationShell",
+                "id": "urn:example:test-aas",
+                "assetInformation": {
+                    "globalAssetId": "urn:example:test-asset",
+                    "assetKind": "Instance"
+                }
+            }
+            """;
+
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            _mockDownstream = new DownstreamService();
+            _mockRegistry = new RegistryMockService();
+
+            var enabledFactory = new IntegrationTestBase(_mockDownstream.Url!, new Dictionary<string, string>
+            {
+                { "Features:AasRegistryMiddleware", "true" },
+                { "ReverseProxy:Clusters:aasRegistryCluster:Destinations:destination1:Address", _mockRegistry.Url! }
+            });
+            _httpClientEnabled = enabledFactory.CreateClient();
+            _httpClientEnabled.DefaultRequestHeaders.Add("X-API-KEY", "verySecureApiKeyMock");
+
+            var disabledFactory = new IntegrationTestBase(_mockDownstream.Url!, new Dictionary<string, string>
+            {
+                { "Features:AasRegistryMiddleware", "false" },
+                { "ReverseProxy:Clusters:aasRegistryCluster:Destinations:destination1:Address", _mockRegistry.Url! }
+            });
+            _httpClientDisabled = disabledFactory.CreateClient();
+            _httpClientDisabled.DefaultRequestHeaders.Add("X-API-KEY", "verySecureApiKeyMock");
+        }
+
+        [SetUp]
+        public void ClearReceivedRequests()
+        {
+            _mockRegistry.Clear();
+        }
+
+        [Test]
+        public async Task Should_Call_Registry_When_POST_To_Repo_With_AAS_Body()
+        {
+            var content = new StringContent(ValidAasBody, Encoding.UTF8, "application/json");
+
+            await _httpClientEnabled.PostAsync("/repo/shells", content);
+
+            await WaitForRegistryCallAsync(() => _mockRegistry.ReceivedRequests.Any(r =>
+                r.Method == "POST" && r.Path.StartsWith("/shell-descriptors")));
+
+            Assert.That(_mockRegistry.ReceivedRequests, Has.Some.Matches<ReceivedRequest>(r =>
+                r.Method == "POST" && r.Path.StartsWith("/shell-descriptors")));
+        }
+
+        [Test]
+        public async Task Should_Call_Registry_When_PUT_To_Repo_With_AAS_Body()
+        {
+            var b64AasId = Base64StringDeAndEncoder.EncodeTo64(AasId);
+            var content = new StringContent(ValidAasBody, Encoding.UTF8, "application/json");
+
+            await _httpClientEnabled.PutAsync($"/repo/shells/{b64AasId}", content);
+
+            await WaitForRegistryCallAsync(() => _mockRegistry.ReceivedRequests.Any(r =>
+                r.Method == "POST" && r.Path.StartsWith("/shell-descriptors")));
+
+            Assert.That(_mockRegistry.ReceivedRequests, Has.Some.Matches<ReceivedRequest>(r =>
+                r.Method == "POST" && r.Path.StartsWith("/shell-descriptors")));
+        }
+
+        [Test]
+        public async Task Should_Call_Registry_When_DELETE_To_Repo()
+        {
+            var b64AasId = Base64StringDeAndEncoder.EncodeTo64(AasId);
+
+            await _httpClientEnabled.DeleteAsync($"/repo/shells/{b64AasId}");
+
+            await WaitForRegistryCallAsync(() => _mockRegistry.ReceivedRequests.Any(r =>
+                r.Method == "DELETE" && r.Path.Contains(b64AasId)));
+
+            Assert.That(_mockRegistry.ReceivedRequests, Has.Some.Matches<ReceivedRequest>(r =>
+                r.Method == "DELETE" && r.Path.Contains(b64AasId)));
+        }
+
+        [Test]
+        public async Task Should_Not_Call_Registry_When_POST_To_Repo_With_Non_AAS_Body()
+        {
+            const string nonAasBody = """{"modelType": "Submodel", "id": "urn:submodel:1"}""";
+            var content = new StringContent(nonAasBody, Encoding.UTF8, "application/json");
+
+            await _httpClientEnabled.PostAsync("/repo/shells", content);
+
+            await Task.Delay(500);
+
+            Assert.That(_mockRegistry.ReceivedRequests, Is.Empty);
+        }
+
+        [Test]
+        public async Task Should_Not_Call_Registry_When_Feature_Flag_Is_Disabled()
+        {
+            var content = new StringContent(ValidAasBody, Encoding.UTF8, "application/json");
+
+            await _httpClientDisabled.PostAsync("/repo/shells", content);
+
+            await Task.Delay(500);
+
+            Assert.That(_mockRegistry.ReceivedRequests, Is.Empty);
+        }
+
+        [OneTimeTearDown]
+        public void Dispose()
+        {
+            _httpClientEnabled.Dispose();
+            _httpClientDisabled.Dispose();
+            _mockDownstream.Dispose();
+            _mockRegistry.Dispose();
+        }
+
+        /// <summary>
+        /// Polls until the condition is true or the timeout expires.
+        /// Needed because registry calls are fire-and-forget and complete after the HTTP response is sent.
+        /// </summary>
+        private static async Task WaitForRegistryCallAsync(Func<bool> condition, int timeoutMs = 2000)
+        {
+            var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+            while (DateTime.UtcNow < deadline)
+            {
+                if (condition()) return;
+                await Task.Delay(100);
+            }
+        }
+    }
+}

--- a/mnestix-proxy.Tests/MiddlewareTests/AasRegistryServiceMiddlewareTests.cs
+++ b/mnestix-proxy.Tests/MiddlewareTests/AasRegistryServiceMiddlewareTests.cs
@@ -1,5 +1,6 @@
 using mnestix_proxy.Services.Shared;
 using mnestix_proxy.Tests.TestMockService;
+using Newtonsoft.Json.Linq;
 using System.Text;
 
 namespace mnestix_proxy.Tests.MiddlewareTests
@@ -22,6 +23,23 @@ namespace mnestix_proxy.Tests.MiddlewareTests
                 "assetInformation": {
                     "globalAssetId": "urn:example:test-asset",
                     "assetKind": "Instance"
+                }
+            }
+            """;
+
+        private static readonly string FullAasBody = """
+            {
+                "modelType": "AssetAdministrationShell",
+                "id": "urn:example:test-aas",
+                "idShort": "TestAas",
+                "description": [{"language": "en", "text": "Test AAS description"}],
+                "displayName": [{"language": "en", "text": "Test AAS"}],
+                "administration": {"version": "1", "revision": "0"},
+                "assetInformation": {
+                    "globalAssetId": "urn:example:test-asset",
+                    "assetKind": "Instance",
+                    "assetType": "TestType",
+                    "specificAssetIds": [{"name": "serialNumber", "value": "12345"}]
                 }
             }
             """;
@@ -121,6 +139,210 @@ namespace mnestix_proxy.Tests.MiddlewareTests
             await Task.Delay(500);
 
             Assert.That(_mockRegistry.ReceivedRequests, Is.Empty);
+        }
+
+        [Test]
+        public async Task Should_POST_Full_Descriptor_With_All_Fields_Mapped_Correctly()
+        {
+            var content = new StringContent(FullAasBody, Encoding.UTF8, "application/json");
+
+            await _httpClientEnabled.PostAsync("/repo/shells", content);
+
+            await WaitForRegistryCallAsync(() => _mockRegistry.ReceivedRequests.Any(r =>
+                r.Method == "POST" && r.Path.StartsWith("/shell-descriptors")));
+
+            var request = _mockRegistry.ReceivedRequests.First(r =>
+                r.Method == "POST" && r.Path.StartsWith("/shell-descriptors"));
+            var descriptor = JObject.Parse(request.Body!);
+            var expectedDescription = JArray.Parse("""[{"language":"en","text":"Test AAS description"}]""");
+            var expectedDisplayName = JArray.Parse("""[{"language":"en","text":"Test AAS"}]""");
+            var expectedSpecificAssetIds = JArray.Parse("""[{"name":"serialNumber","value":"12345"}]""");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(request.Path, Is.EqualTo("/shell-descriptors"), "request path");
+
+                // Core identity
+                Assert.That(descriptor["id"]?.Value<string>(), Is.EqualTo(AasId), "id");
+                Assert.That(descriptor["globalAssetId"]?.Value<string>(), Is.EqualTo(AssetId), "globalAssetId");
+
+                // Pass-through metadata fields
+                Assert.That(descriptor["idShort"]?.Value<string>(), Is.EqualTo("TestAas"), "idShort");
+                Assert.That(JToken.DeepEquals(descriptor["description"], expectedDescription), Is.True, "description");
+                Assert.That(JToken.DeepEquals(descriptor["displayName"], expectedDisplayName), Is.True, "displayName");
+                Assert.That(descriptor["administration"]?["version"]?.Value<string>(), Is.EqualTo("1"), "administration.version");
+                Assert.That(descriptor["administration"]?["revision"]?.Value<string>(), Is.EqualTo("0"), "administration.revision");
+
+                // Flattened assetInformation fields
+                Assert.That(descriptor["assetKind"]?.Value<string>(), Is.EqualTo("Instance"), "assetKind");
+                Assert.That(descriptor["assetType"]?.Value<string>(), Is.EqualTo("TestType"), "assetType");
+                Assert.That(JToken.DeepEquals(descriptor["specificAssetIds"], expectedSpecificAssetIds), Is.True, "specificAssetIds");
+                Assert.That(descriptor["assetInformation"], Is.Null, "assetInformation should be flattened away");
+
+                // modelType must NOT be in the registry descriptor
+                Assert.That(descriptor["modelType"], Is.Null, "modelType should not be present in descriptor");
+
+                // Endpoint pointing to the proxy's /repo/shells/{base64Id}
+                var endpoints = descriptor["endpoints"] as JArray;
+                Assert.That(endpoints, Has.Count.EqualTo(1), "endpoints array");
+                var endpoint = endpoints![0];
+                Assert.That(endpoint["interface"]?.Value<string>(), Is.EqualTo("AAS-3.0"), "endpoint interface");
+                var href = endpoint["protocolInformation"]?["href"]?.Value<string>();
+                Assert.That(href, Does.Contain("/repo/shells/"), "endpoint href should contain /repo/shells/");
+                Assert.That(href, Does.Contain(Base64StringDeAndEncoder.EncodeTo64(AasId)),
+                    "endpoint href should contain the base64-encoded AAS id");
+                Assert.That(endpoint["protocolInformation"]?["endpointProtocol"]?.Value<string>(), Is.EqualTo("HTTP"),
+                    "endpoint protocol");
+                Assert.That(JToken.DeepEquals(endpoint["protocolInformation"]?["endpointProtocolVersion"], new JArray("1.1")),
+                    Is.True, "endpoint protocol version");
+            });
+        }
+
+        [Test]
+        public async Task Should_POST_Descriptor_With_Only_Required_Fields_When_AAS_Body_Is_Minimal()
+        {
+            var content = new StringContent(ValidAasBody, Encoding.UTF8, "application/json");
+
+            await _httpClientEnabled.PostAsync("/repo/shells", content);
+
+            await WaitForRegistryCallAsync(() => _mockRegistry.ReceivedRequests.Any(r =>
+                r.Method == "POST" && r.Path.StartsWith("/shell-descriptors")));
+
+            var request = _mockRegistry.ReceivedRequests.First(r =>
+                r.Method == "POST" && r.Path.StartsWith("/shell-descriptors"));
+            var descriptor = JObject.Parse(request.Body!);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(request.Path, Is.EqualTo("/shell-descriptors"), "request path");
+                Assert.That(descriptor["id"]?.Value<string>(), Is.EqualTo(AasId), "id");
+                Assert.That(descriptor["globalAssetId"]?.Value<string>(), Is.EqualTo(AssetId), "globalAssetId");
+                Assert.That(descriptor["assetKind"]?.Value<string>(), Is.EqualTo("Instance"), "assetKind");
+                Assert.That(descriptor["modelType"], Is.Null, "modelType should not be present");
+
+                // Optional fields must be absent when not in source AAS body
+                Assert.That(descriptor["idShort"], Is.Null, "idShort should be absent for minimal body");
+                Assert.That(descriptor["description"], Is.Null, "description should be absent for minimal body");
+                Assert.That(descriptor["displayName"], Is.Null, "displayName should be absent for minimal body");
+                Assert.That(descriptor["administration"], Is.Null, "administration should be absent for minimal body");
+                Assert.That(descriptor["specificAssetIds"], Is.Null, "specificAssetIds should be absent for minimal body");
+
+                // Endpoint should always be present
+                var endpoints = descriptor["endpoints"] as JArray;
+                Assert.That(endpoints, Has.Count.EqualTo(1), "endpoints array");
+
+                Assert.That(descriptor.Properties().Select(property => property.Name), Is.EquivalentTo(new[]
+                {
+                    "id",
+                    "globalAssetId",
+                    "assetKind",
+                    "endpoints"
+                }), "minimal descriptor should contain only the expected fields");
+            });
+        }
+
+        [Test]
+        public async Task Should_Not_Call_Registry_When_AAS_Body_Is_Missing_Id()
+        {
+            const string bodyMissingId = """
+                {
+                    "modelType": "AssetAdministrationShell",
+                    "assetInformation": {
+                        "globalAssetId": "urn:example:test-asset",
+                        "assetKind": "Instance"
+                    }
+                }
+                """;
+            var content = new StringContent(bodyMissingId, Encoding.UTF8, "application/json");
+
+            await _httpClientEnabled.PostAsync("/repo/shells", content);
+
+            await Task.Delay(500);
+
+            Assert.That(_mockRegistry.ReceivedRequests, Is.Empty);
+        }
+
+        [Test]
+        public async Task Should_Not_Call_Registry_When_AAS_Body_Is_Missing_AssetInformation()
+        {
+            const string bodyMissingAssetInfo = """
+                {
+                    "modelType": "AssetAdministrationShell",
+                    "id": "urn:example:test-aas"
+                }
+                """;
+            var content = new StringContent(bodyMissingAssetInfo, Encoding.UTF8, "application/json");
+
+            await _httpClientEnabled.PostAsync("/repo/shells", content);
+
+            await Task.Delay(500);
+
+            Assert.That(_mockRegistry.ReceivedRequests, Is.Empty);
+        }
+
+        [Test]
+        public async Task Should_Not_Call_Registry_When_AAS_Body_Is_Missing_GlobalAssetId()
+        {
+            const string bodyMissingGlobalAssetId = """
+                {
+                    "modelType": "AssetAdministrationShell",
+                    "id": "urn:example:test-aas",
+                    "assetInformation": {
+                        "assetKind": "Instance"
+                    }
+                }
+                """;
+            var content = new StringContent(bodyMissingGlobalAssetId, Encoding.UTF8, "application/json");
+
+            await _httpClientEnabled.PostAsync("/repo/shells", content);
+
+            await Task.Delay(500);
+
+            Assert.That(_mockRegistry.ReceivedRequests, Is.Empty);
+        }
+
+        [Test]
+        public async Task Should_Not_Call_Registry_When_Body_Is_Not_Valid_Json()
+        {
+            var content = new StringContent("not-valid-json{{{{", Encoding.UTF8, "application/json");
+
+            await _httpClientEnabled.PostAsync("/repo/shells", content);
+
+            await Task.Delay(500);
+
+            Assert.That(_mockRegistry.ReceivedRequests, Is.Empty);
+        }
+
+        [Test]
+        public async Task Proxy_Should_Return_Success_When_Registry_Returns_Server_Error()
+        {
+            _mockRegistry.ForcedStatusCode = StatusCodes.Status500InternalServerError;
+            try
+            {
+                var content = new StringContent(ValidAasBody, Encoding.UTF8, "application/json");
+
+                var response = await _httpClientEnabled.PostAsync("/repo/shells", content);
+
+                // The proxy forwards to downstream (200 OK) regardless of registry outcome
+                Assert.That(response.IsSuccessStatusCode, Is.True,
+                    "Proxy should return a successful response even when the registry call fails");
+                Assert.That(response.StatusCode, Is.EqualTo(System.Net.HttpStatusCode.OK),
+                    "Proxy should preserve the downstream success status");
+                Assert.That(await response.Content.ReadAsStringAsync(), Is.EqualTo("AAS Repository Service called!"),
+                    "Proxy should still return the downstream response body");
+
+                // The middleware still attempted to reach the registry (fire-and-forget ran)
+                await WaitForRegistryCallAsync(() => _mockRegistry.ReceivedRequests.Any(r =>
+                    r.Method == "POST" && r.Path.StartsWith("/shell-descriptors")));
+
+                Assert.That(_mockRegistry.ReceivedRequests, Has.Some.Matches<ReceivedRequest>(r =>
+                    r.Method == "POST" && r.Path.StartsWith("/shell-descriptors")),
+                    "Registry should have been called despite returning an error");
+            }
+            finally
+            {
+                _mockRegistry.ForcedStatusCode = null;
+            }
         }
 
         [OneTimeTearDown]

--- a/mnestix-proxy.Tests/TestMockService/RegistryMockService.cs
+++ b/mnestix-proxy.Tests/TestMockService/RegistryMockService.cs
@@ -1,0 +1,96 @@
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+
+namespace mnestix_proxy.Tests.TestMockService
+{
+    /// <summary>
+    /// A lightweight HTTP mock server for the AAS Registry that records every request it receives.
+    /// Tests can inspect ReceivedRequests to verify the middleware made the expected side-calls.
+    /// </summary>
+    public class RegistryMockService : IDisposable
+    {
+        private IHost? _host;
+        public string? Url;
+
+        private readonly List<ReceivedRequest> _receivedRequests = [];
+        private readonly object _lock = new();
+
+        public IReadOnlyList<ReceivedRequest> ReceivedRequests
+        {
+            get { lock (_lock) { return [.. _receivedRequests]; } }
+        }
+
+        public void Clear()
+        {
+            lock (_lock) { _receivedRequests.Clear(); }
+        }
+
+        public RegistryMockService()
+        {
+            StartServer();
+        }
+
+        private void StartServer()
+        {
+            if (_host != null) return;
+            _host = Host.CreateDefaultBuilder()
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseKestrel()
+                              .UseUrls("http://127.0.0.1:0")
+                              .Configure(app =>
+                              {
+                                  app.Run(async context =>
+                                  {
+                                      var method = context.Request.Method;
+                                      var path = context.Request.Path.Value ?? string.Empty;
+
+                                      var body = string.Empty;
+                                      if (context.Request.ContentLength > 0)
+                                      {
+                                          using var reader = new StreamReader(context.Request.Body);
+                                          body = await reader.ReadToEndAsync();
+                                      }
+
+                                      lock (_lock)
+                                      {
+                                          _receivedRequests.Add(new ReceivedRequest(method, path, body));
+                                      }
+
+                                      if (path.StartsWith("/shell-descriptors", StringComparison.OrdinalIgnoreCase))
+                                      {
+                                          context.Response.StatusCode = method switch
+                                          {
+                                              "POST" => StatusCodes.Status201Created,
+                                              "DELETE" => StatusCodes.Status204NoContent,
+                                              _ => StatusCodes.Status200OK
+                                          };
+                                      }
+                                      else
+                                      {
+                                          context.Response.StatusCode = StatusCodes.Status404NotFound;
+                                      }
+                                  });
+                              });
+                })
+                .Start();
+
+            var address = _host.Services?
+                .GetRequiredService<IServer>()?
+                .Features?
+                .Get<IServerAddressesFeature>()?
+                .Addresses
+                .First();
+
+            if (address == null) return;
+            Url = address.TrimEnd('/');
+        }
+
+        public void Dispose()
+        {
+            _host?.Dispose();
+        }
+    }
+
+    public record ReceivedRequest(string Method, string Path, string? Body);
+}

--- a/mnestix-proxy.Tests/TestMockService/RegistryMockService.cs
+++ b/mnestix-proxy.Tests/TestMockService/RegistryMockService.cs
@@ -15,6 +15,11 @@ namespace mnestix_proxy.Tests.TestMockService
         private readonly List<ReceivedRequest> _receivedRequests = [];
         private readonly object _lock = new();
 
+        /// <summary>
+        /// When set, overrides the default status code for all responses. Use to simulate registry errors.
+        /// </summary>
+        public int? ForcedStatusCode { get; set; }
+
         public IReadOnlyList<ReceivedRequest> ReceivedRequests
         {
             get { lock (_lock) { return [.. _receivedRequests]; } }
@@ -59,7 +64,7 @@ namespace mnestix_proxy.Tests.TestMockService
 
                                       if (path.StartsWith("/shell-descriptors", StringComparison.OrdinalIgnoreCase))
                                       {
-                                          context.Response.StatusCode = method switch
+                                          context.Response.StatusCode = ForcedStatusCode ?? method switch
                                           {
                                               "POST" => StatusCodes.Status201Created,
                                               "DELETE" => StatusCodes.Status204NoContent,

--- a/mnestix-proxy/Configuration/RegistryServiceOptions.cs
+++ b/mnestix-proxy/Configuration/RegistryServiceOptions.cs
@@ -1,0 +1,15 @@
+namespace mnestix_proxy.Configuration
+{
+    public class RegistryServiceOptions
+    {
+        /// <summary>
+        /// Name of the configuration section in appsettings.json
+        /// </summary>
+        public const string Options = "ReverseProxy:Clusters:aasRegistryCluster:Destinations:destination1";
+
+        /// <summary>
+        /// The base address of the AAS Registry service.
+        /// </summary>
+        public string Address { get; set; } = string.Empty;
+    }
+}

--- a/mnestix-proxy/Middleware/AasRegistryServiceMiddleware.cs
+++ b/mnestix-proxy/Middleware/AasRegistryServiceMiddleware.cs
@@ -62,7 +62,10 @@ namespace mnestix_proxy.Middleware
 
                     if (aasId != null && assetId != null)
                     {
-                        _ = registryClient.RegisterOrUpdateShellDescriptor(aasId: aasId, globalAssetId: assetId)
+                        var baseUrl = $"{context.Request.Scheme}://{context.Request.Host}";
+                        var descriptor = BuildShellDescriptor(requestBody, aasId, baseUrl);
+
+                        _ = registryClient.RegisterOrUpdateShellDescriptor(aasId: aasId, shellDescriptorJson: descriptor.ToString())
                             .ContinueWith(t =>
                             {
                                 if (t.IsFaulted)
@@ -102,6 +105,58 @@ namespace mnestix_proxy.Middleware
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Converts an AssetAdministrationShell body (AAS Repository format) into an
+        /// AssetAdministrationShellDescriptor (AAS Registry format), mapping all available
+        /// fields and appending an endpoint pointing back to this proxy.
+        /// </summary>
+        private static JObject BuildShellDescriptor(JObject aasBody, string aasId, string proxyBaseUrl)
+        {
+            var assetInfo = aasBody["assetInformation"];
+
+            var descriptor = new JObject
+            {
+                ["id"] = aasId,
+                ["globalAssetId"] = assetInfo?["globalAssetId"]
+            };
+
+            // Pass-through optional metadata fields
+            if (aasBody["idShort"] is { } idShort)
+                descriptor["idShort"] = idShort;
+            if (aasBody["description"] is { } description)
+                descriptor["description"] = description;
+            if (aasBody["displayName"] is { } displayName)
+                descriptor["displayName"] = displayName;
+            if (aasBody["administration"] is { } administration)
+                descriptor["administration"] = administration;
+
+            // Flatten assetInformation fields to the descriptor top level
+            if (assetInfo?["assetKind"] is { } assetKind)
+                descriptor["assetKind"] = assetKind;
+            if (assetInfo?["assetType"] is { } assetType)
+                descriptor["assetType"] = assetType;
+            if (assetInfo?["specificAssetIds"] is { } specificAssetIds)
+                descriptor["specificAssetIds"] = specificAssetIds;
+
+            // Endpoint pointing to this proxy's repo path for the AAS
+            var href = $"{proxyBaseUrl}/repo/shells/{Base64StringDeAndEncoder.EncodeTo64(aasId)}";
+            descriptor["endpoints"] = new JArray
+            {
+                new JObject
+                {
+                    ["protocolInformation"] = new JObject
+                    {
+                        ["href"] = href,
+                        ["endpointProtocol"] = "HTTP",
+                        ["endpointProtocolVersion"] = new JArray { "1.1" }
+                    },
+                    ["interface"] = "AAS-3.0"
+                }
+            };
+
+            return descriptor;
         }
     }
 }

--- a/mnestix-proxy/Middleware/AasRegistryServiceMiddleware.cs
+++ b/mnestix-proxy/Middleware/AasRegistryServiceMiddleware.cs
@@ -1,0 +1,107 @@
+using mnestix_proxy.Services.Clients;
+using mnestix_proxy.Services.Shared;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Text;
+
+namespace mnestix_proxy.Middleware
+{
+    /// <summary>
+    /// This middleware class is responsible for registering and deregistering AAS shell descriptors
+    /// in the AAS Registry whenever shells are created, updated, or deleted via the repository.
+    /// </summary>
+    public static class AasRegistryServiceMiddleware
+    {
+        internal static Func<HttpContext, Func<Task>, Task> ConfigureAasRegistryHandling()
+        {
+            return (context, next) =>
+            {
+                var registryClient = context.RequestServices.GetRequiredService<IRegistryClient>();
+                var logger = context.RequestServices.GetRequiredService<ILoggerFactory>()
+                    .CreateLogger(nameof(AasRegistryServiceMiddleware));
+
+                switch (context.Request.Method)
+                {
+                    case "PUT" or "POST" when context.Request.Path.HasValue &&
+                                              context.Request.Path.StartsWithSegments("/repo"):
+                        HandlePutToRepo(context, registryClient, logger);
+                        break;
+                    case "DELETE" when context.Request.Path.HasValue &&
+                                       context.Request.Path.StartsWithSegments("/repo"):
+                        _ = HandleDeleteFromRepoAsync(context, registryClient, logger);
+                        break;
+                }
+
+                return next();
+            };
+        }
+
+        private static void HandlePutToRepo(HttpContext context, IRegistryClient registryClient, ILogger logger)
+        {
+            context.Request.EnableBuffering();
+            using (var reader
+                   = new StreamReader(context.Request.Body, Encoding.UTF8, true, 1024, true))
+            {
+                var requestBody = new JObject();
+                try
+                {
+                    var bodyStr = reader.ReadToEndAsync();
+                    requestBody = JObject.Parse(bodyStr.Result);
+                }
+                catch (JsonReaderException)
+                {
+                    // we do not want to break the request here.
+                    // if the request cannot be parsed it might be a single value for a submodel element which the repo will handle correctly.
+                }
+
+                var modelType = requestBody["modelType"]?.Value<string>();
+                if (modelType is "AssetAdministrationShell")
+                {
+                    var assetId = requestBody["assetInformation"]?["globalAssetId"]?.Value<string>();
+                    var aasId = requestBody["id"]?.Value<string>();
+
+                    if (aasId != null && assetId != null)
+                    {
+                        _ = registryClient.RegisterOrUpdateShellDescriptor(aasId: aasId, globalAssetId: assetId)
+                            .ContinueWith(t =>
+                            {
+                                if (t.IsFaulted)
+                                    logger.LogError(t.Exception, "Unexpected error registering AAS {AasId} in registry.", aasId);
+                                else if (!t.Result.isSuccess)
+                                    logger.LogWarning("Failed to register AAS {AasId} in registry: {Result}", aasId, t.Result.Result);
+                            }, TaskScheduler.Default);
+                    }
+                }
+            }
+
+            // Rewind so the core request body is not lost when the proxy forwards the request
+            context.Request.Body.Position = 0;
+        }
+
+        private static async Task HandleDeleteFromRepoAsync(HttpContext context, IRegistryClient registryClient, ILogger logger)
+        {
+            // DELETE /repo/shells/{base64AasId} — the AAS ID is encoded in the URL path
+            var segments = context.Request.Path.Value?.Split('/') ?? [];
+
+            // Expected path segments: ["", "repo", "shells", "{base64AasId}"]
+            if (segments.Length >= 4 && segments[2].Equals("shells", StringComparison.OrdinalIgnoreCase))
+            {
+                var b64AasId = segments[3];
+                if (!string.IsNullOrEmpty(b64AasId))
+                {
+                    try
+                    {
+                        var aasId = Base64StringDeAndEncoder.DecodeFrom64(b64AasId);
+                        var (isSuccess, result) = await registryClient.DeleteShellDescriptor(aasIdentifier: aasId);
+                        if (!isSuccess)
+                            logger.LogWarning("Failed to delete shell descriptor for AAS {AasId}: {Result}", aasId, result);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogError(ex, "Unexpected error deleting shell descriptor for AAS ID segment {B64AasId}.", b64AasId);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/mnestix-proxy/Program.cs
+++ b/mnestix-proxy/Program.cs
@@ -21,6 +21,11 @@ namespace mnestix_proxy
             builder.Services.Configure<DiscoveryServiceOptions>(
                 builder.Configuration.GetSection(DiscoveryServiceOptions.Options));
 
+            // Registry Client settings
+            builder.Services.AddTransient<IRegistryClient, RegistryClient>();
+            builder.Services.Configure<RegistryServiceOptions>(
+                builder.Configuration.GetSection(RegistryServiceOptions.Options));
+
             builder.Services.AddAuthenticationServices(builder.Configuration);
 
             // Adds authorization handler
@@ -64,12 +69,20 @@ namespace mnestix_proxy
                     proxyPipeline.Use(PathRestrictionMiddleware.PathRestrictionHandling());
                 }
 
-                // AAS registry
+                // AAS Discovery
                 _ = bool.TryParse(builder.Configuration["Features:AasDiscoveryMiddleware"],
+                    out var aasDiscoveryMiddleware);
+                if (aasDiscoveryMiddleware)
+                {
+                    proxyPipeline.Use(AasDiscoveryServiceMiddleware.ConfigureAasDiscoveryHandling());
+                }
+
+                // AAS Registry
+                _ = bool.TryParse(builder.Configuration["Features:AasRegistryMiddleware"],
                     out var aasRegistryMiddleware);
                 if (aasRegistryMiddleware)
                 {
-                    proxyPipeline.Use(AasDiscoveryServiceMiddleware.ConfigureAasDiscoveryHandling());
+                    proxyPipeline.Use(AasRegistryServiceMiddleware.ConfigureAasRegistryHandling());
                 }
 
                 // MQTT Eventing

--- a/mnestix-proxy/Services/Clients/IRegistryClient.cs
+++ b/mnestix-proxy/Services/Clients/IRegistryClient.cs
@@ -2,7 +2,7 @@ namespace mnestix_proxy.Services.Clients
 {
     public interface IRegistryClient
     {
-        Task<(bool isSuccess, string Result)> RegisterOrUpdateShellDescriptor(string aasId, string globalAssetId);
+        Task<(bool isSuccess, string Result)> RegisterOrUpdateShellDescriptor(string aasId, string shellDescriptorJson);
         Task<(bool isSuccess, string Result)> DeleteShellDescriptor(string aasIdentifier);
     }
 }

--- a/mnestix-proxy/Services/Clients/IRegistryClient.cs
+++ b/mnestix-proxy/Services/Clients/IRegistryClient.cs
@@ -1,0 +1,8 @@
+namespace mnestix_proxy.Services.Clients
+{
+    public interface IRegistryClient
+    {
+        Task<(bool isSuccess, string Result)> RegisterOrUpdateShellDescriptor(string aasId, string globalAssetId);
+        Task<(bool isSuccess, string Result)> DeleteShellDescriptor(string aasIdentifier);
+    }
+}

--- a/mnestix-proxy/Services/Clients/RegistryClient.cs
+++ b/mnestix-proxy/Services/Clients/RegistryClient.cs
@@ -1,0 +1,81 @@
+using Microsoft.Extensions.Options;
+using mnestix_proxy.Configuration;
+using mnestix_proxy.Services.Shared;
+using Newtonsoft.Json.Linq;
+using RestSharp;
+using System.Net;
+
+namespace mnestix_proxy.Services.Clients
+{
+    public class RegistryClient(IOptions<RegistryServiceOptions> options) : IRegistryClient
+    {
+        public async Task<(bool isSuccess, string Result)> RegisterOrUpdateShellDescriptor(string aasId, string globalAssetId)
+        {
+            var client = new RestClient(options.Value.Address);
+            var b64AasId = Base64StringDeAndEncoder.EncodeTo64(aasId);
+
+            var descriptor = new JObject
+            {
+                { "id", aasId },
+                { "globalAssetId", globalAssetId }
+            };
+
+            // Try POST first (create new descriptor)
+            var postRequest = new RestRequest("/shell-descriptors")
+            {
+                RequestFormat = DataFormat.Json,
+                Method = Method.Post
+            };
+            postRequest.AddBody(descriptor.ToString(), "application/json");
+
+            var postResponse = await client.PostAsync(postRequest);
+
+            if (postResponse.StatusCode is HttpStatusCode.Created or HttpStatusCode.OK)
+            {
+                return (true, postResponse.Content ?? string.Empty);
+            }
+
+            // If conflict (409), the descriptor already exists — update it via PUT
+            if (postResponse.StatusCode == HttpStatusCode.Conflict)
+            {
+                var putRequest = new RestRequest("/shell-descriptors/" + b64AasId)
+                {
+                    RequestFormat = DataFormat.Json,
+                    Method = Method.Put
+                };
+                putRequest.AddBody(descriptor.ToString(), "application/json");
+
+                var putResponse = await client.PutAsync(putRequest);
+
+                if (putResponse.StatusCode is HttpStatusCode.OK or HttpStatusCode.NoContent)
+                {
+                    return (true, putResponse.Content ?? string.Empty);
+                }
+
+                return (false, $"Could not update shell descriptor: {putResponse.Content} Code: {putResponse.StatusCode}");
+            }
+
+            return (false, $"Could not register shell descriptor: {postResponse.Content} Code: {postResponse.StatusCode}");
+        }
+
+        public async Task<(bool isSuccess, string Result)> DeleteShellDescriptor(string aasIdentifier)
+        {
+            var client = new RestClient(options.Value.Address);
+            var b64AasId = Base64StringDeAndEncoder.EncodeTo64(aasIdentifier);
+            var request = new RestRequest("/shell-descriptors/" + b64AasId)
+            {
+                RequestFormat = DataFormat.Json,
+                Method = Method.Delete
+            };
+
+            var response = await client.DeleteAsync(request);
+
+            if (response.StatusCode is not (HttpStatusCode.NoContent or HttpStatusCode.OK))
+            {
+                return (false, $"Could not delete shell descriptor: {response.Content} Code: {response.StatusCode}");
+            }
+
+            return (true, response.Content ?? string.Empty);
+        }
+    }
+}

--- a/mnestix-proxy/Services/Clients/RegistryClient.cs
+++ b/mnestix-proxy/Services/Clients/RegistryClient.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.Options;
 using mnestix_proxy.Configuration;
 using mnestix_proxy.Services.Shared;
-using Newtonsoft.Json.Linq;
 using RestSharp;
 using System.Net;
 
@@ -9,16 +8,10 @@ namespace mnestix_proxy.Services.Clients
 {
     public class RegistryClient(IOptions<RegistryServiceOptions> options) : IRegistryClient
     {
-        public async Task<(bool isSuccess, string Result)> RegisterOrUpdateShellDescriptor(string aasId, string globalAssetId)
+        public async Task<(bool isSuccess, string Result)> RegisterOrUpdateShellDescriptor(string aasId, string shellDescriptorJson)
         {
             var client = new RestClient(options.Value.Address);
             var b64AasId = Base64StringDeAndEncoder.EncodeTo64(aasId);
-
-            var descriptor = new JObject
-            {
-                { "id", aasId },
-                { "globalAssetId", globalAssetId }
-            };
 
             // Try POST first (create new descriptor)
             var postRequest = new RestRequest("/shell-descriptors")
@@ -26,7 +19,7 @@ namespace mnestix_proxy.Services.Clients
                 RequestFormat = DataFormat.Json,
                 Method = Method.Post
             };
-            postRequest.AddBody(descriptor.ToString(), "application/json");
+            postRequest.AddBody(shellDescriptorJson, "application/json");
 
             var postResponse = await client.PostAsync(postRequest);
 
@@ -43,7 +36,7 @@ namespace mnestix_proxy.Services.Clients
                     RequestFormat = DataFormat.Json,
                     Method = Method.Put
                 };
-                putRequest.AddBody(descriptor.ToString(), "application/json");
+                putRequest.AddBody(shellDescriptorJson, "application/json");
 
                 var putResponse = await client.PutAsync(putRequest);
 

--- a/mnestix-proxy/appsettings.json
+++ b/mnestix-proxy/appsettings.json
@@ -29,7 +29,8 @@
   },
   "Features": {
     "AllowRetrievingAllShellsAndSubmodels": "true",
-    "AasDiscoveryMiddleware": "true"
+    "AasDiscoveryMiddleware": "true",
+    "AasRegistryMiddleware": "true"
   },
   "AllowedHosts": "*",
   "ReverseProxy": {


### PR DESCRIPTION
# MR Overview: AAS Registry Middleware

## Summary

This MR adds `AasRegistryServiceMiddleware` so repository writes to `/repo` are mirrored to the **AAS Registry**. When an `AssetAdministrationShell` is created, updated, or deleted through the repository, the middleware creates, updates, or removes the corresponding **shell descriptor** in the registry without blocking the proxied repository request.

---

## Files Added

### `mnestix-proxy/Configuration/RegistryServiceOptions.cs`

Configuration binding class for the AAS Registry cluster address. Reads from `ReverseProxy:Clusters:aasRegistryCluster:Destinations:destination1`.

### `mnestix-proxy/Services/Clients/IRegistryClient.cs`

Interface for the registry client exposing:

- `RegisterOrUpdateShellDescriptor(aasId, shellDescriptorJson)`
- `DeleteShellDescriptor(aasIdentifier)`

### `mnestix-proxy/Services/Clients/RegistryClient.cs`

RestSharp-based implementation of the AAS Registry Part 2 calls:

- **Register/Update**: `POST /shell-descriptors` with the full descriptor JSON. On `409 Conflict`, falls back to `PUT /shell-descriptors/{base64Id}`.
- **Delete**: `DELETE /shell-descriptors/{base64Id}`

### `mnestix-proxy/Middleware/AasRegistryServiceMiddleware.cs`

Middleware registered in the YARP pipeline when `Features:AasRegistryMiddleware` is enabled.

- **POST/PUT to `/repo`**: reads and rewinds the request body before the proxy continues, checks for `modelType == "AssetAdministrationShell"`, converts the repository body into a registry `AssetAdministrationShellDescriptor`, and fires a non-blocking registry call.
- **DELETE to `/repo/shells/{base64AasId}`**: extracts the shell id from the URL and fires a non-blocking delete against the registry.
- Registry failures are logged as warnings/errors and do **not** fail the repository request.

### `mnestix-proxy.Tests/TestMockService/RegistryMockService.cs`

In-process Kestrel mock used by integration tests. Records all received requests and supports overriding the response status code via `ForcedStatusCode` to simulate registry failures.

### `mnestix-proxy.Tests/MiddlewareTests/AasRegistryServiceMiddlewareTests.cs`

12 integration tests covering both invocation and payload behavior:

| Test | Verifies |
|---|---|
| `Should_Call_Registry_When_POST_To_Repo_With_AAS_Body` | Registry receives a POST for repository shell creation |
| `Should_Call_Registry_When_PUT_To_Repo_With_AAS_Body` | Registry receives a POST/PUT flow for repository shell update |
| `Should_Call_Registry_When_DELETE_To_Repo` | Registry receives a delete for repository shell deletion |
| `Should_Not_Call_Registry_When_POST_To_Repo_With_Non_AAS_Body` | Non-AAS payloads are ignored |
| `Should_Not_Call_Registry_When_Feature_Flag_Is_Disabled` | Feature flag disables middleware behavior |
| `Should_POST_Full_Descriptor_With_All_Fields_Mapped_Correctly` | Full AAS payload is converted to the expected shell descriptor shape |
| `Should_POST_Descriptor_With_Only_Required_Fields_When_AAS_Body_Is_Minimal` | Minimal AAS payload produces only the expected minimal descriptor fields |
| `Should_Not_Call_Registry_When_AAS_Body_Is_Missing_Id` | Missing shell id skips registry registration |
| `Should_Not_Call_Registry_When_AAS_Body_Is_Missing_AssetInformation` | Missing `assetInformation` skips registry registration |
| `Should_Not_Call_Registry_When_AAS_Body_Is_Missing_GlobalAssetId` | Missing `globalAssetId` skips registry registration |
| `Should_Not_Call_Registry_When_Body_Is_Not_Valid_Json` | Invalid JSON bodies do not trigger registry calls |
| `Proxy_Should_Return_Success_When_Registry_Returns_Server_Error` | Registry failures do not break the proxied repository response |

Tests use polling to account for the fire-and-forget side calls and now assert both payload content and resilience behavior.

---

## Files Modified

### `mnestix-proxy/Program.cs`

- Registers `IRegistryClient` / `RegistryClient`
- Binds `RegistryServiceOptions`
- Adds `AasRegistryServiceMiddleware` to the YARP pipeline behind `Features:AasRegistryMiddleware`

### `mnestix-proxy/appsettings.json`

- Adds `"AasRegistryMiddleware": "true"` under `Features`

### `mnestix-proxy.Tests/IntegrationTestBase.cs`

- Disables discovery and registry middleware by default in tests
- Adds `aasRegistryCluster` destination used by registry middleware tests

---

## Descriptor Mapping

`BuildShellDescriptor` converts the repository `AssetAdministrationShell` payload into an AAS Registry shell descriptor:

- `id` -> `id`
- `assetInformation.globalAssetId` -> `globalAssetId`
- `idShort`, `description`, `displayName`, `administration` -> copied through when present
- `assetInformation.assetKind`, `assetType`, `specificAssetIds` -> flattened to descriptor top-level
- `modelType` -> intentionally omitted
- `assetInformation` -> not copied as a nested object
- `endpoints` -> generated to point back to this proxy at `/repo/shells/{base64AasId}`

---

## Design Notes

- **Fire-and-forget by design**: registry synchronization must not block or fail repository traffic.
- **Body handling is synchronous before proxying**: the middleware must read and rewind the request body before YARP forwards it.
- **DELETE uses the URL path**: shell deletion is derived from `/repo/shells/{base64AasId}` instead of a request body.